### PR TITLE
Lower Base Image Version

### DIFF
--- a/dockers/Dockerfile
+++ b/dockers/Dockerfile
@@ -1,7 +1,7 @@
 # supported are cuda and cpu
 ARG HARDWARE=cuda
 
-FROM nvcr.io/nvidia/pytorch:22.04-py3 as base_cuda
+FROM nvcr.io/nvidia/pytorch:21.12-py3 as base_cuda
 ARG PYPI_OPTIONS=""
 
 ARG PYPI_OPTIONS=""


### PR DESCRIPTION
Internal cluster still has machines with Nvidia Driver 495 -> 21.21-py3 is the latest image supporting it (see https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html#framework-matrix-2021 )